### PR TITLE
fix(audit): The ownerUnpause() function does not unpause the contract

### DIFF
--- a/evm/src/xPOKT/ConfigurablePauseGuardian.sol
+++ b/evm/src/xPOKT/ConfigurablePauseGuardian.sol
@@ -42,7 +42,7 @@ contract ConfigurablePauseGuardian is ConfigurablePause {
     /// 1). kicks the current guardian
     /// 2). sets pauseUsed to false
     /// 3). unpauses the contracts by setting pause time to 0
-    function _resetPauseState() private {
+    function _resetPauseState() internal {
         address previousPauseGuardian = pauseGuardian;
 
         /// remove the pause guardian

--- a/evm/src/xPOKT/xPOKT.sol
+++ b/evm/src/xPOKT/xPOKT.sol
@@ -174,7 +174,7 @@ contract xPOKT is
     /// @notice unpauses this contract, only callable by owner
     /// allows the owner to unpause the contract when the guardian has paused
     function ownerUnpause() external onlyOwner whenPaused {
-        _unpause();
+        _resetPauseState();
     }
 
     /// @notice update the pause duration

--- a/evm/test/unit/xPOKT.t.sol
+++ b/evm/test/unit/xPOKT.t.sol
@@ -794,7 +794,7 @@ contract xPOKTUnitTest is BaseTest {
         assertTrue(xpoktProxy.paused());
 
         xpoktProxy.ownerUnpause();
-        assertTrue(xpoktProxy.paused(), "contract not unpaused");
+        assertFalse(xpoktProxy.paused(), "contract is unpaused");
     }
 
     function testOwnerUnpauseFailsNotPaused() public {


### PR DESCRIPTION
**File(s)**: xPOKT.sol

**Description**: The xPOKT contract incorporates a pausing mechanism by inheriting from the ConfigurablePausableGuardian contract. This mechanism allows pausing guardians to pause the contract for a specific period, after which it automatically unpauses. Upon unpausing, it is necessary to reset the pauseStartTime variable to restore the pausing mechanism fully. The pauseStartTime can be reset by unpausing the contract via a guardian (while the contract is still paused), removing the guardian, or the contract owner appointing a new guardian.

If the contract is paused, the owner has the ability to unpause it by invoking ownerUnpause(). However, this function is currently misimplemented, as it calls the _unpause() internal method inherited from PausableUpgradable in OpenZeppelin (OZ). This internal method resets the paused state variable but does not affect pauseStartTime.

To correctly implement the owner's unpausing functionality, the internal method _resetPauseState() should be invoked. This method will remove the current guardian and reset the pauseStartTime to zero.

**Recommendation(s)**: To fix this issue, replace _unpause() inside ownerUnpause() with _resetPauseState() internal function.