### PR TITLE
fix(audit): Allowing excessive funds in _bridgeTo(...) function is unnecessary

### DIFF
--- a/evm/src/xPOKT/WPOKTRouter.sol
+++ b/evm/src/xPOKT/WPOKTRouter.sol
@@ -20,7 +20,7 @@ contract WPOKTRouter {
     /// @notice the xPOKT token
     xPOKT public immutable xpokt;
 
-    /// @notice standard POKT token
+    /// @notice standard WPOKT token
     ERC20 public immutable wpokt;
 
     /// @notice xPOKT lockbox to convert wpokt to xpokt
@@ -29,7 +29,7 @@ contract WPOKTRouter {
     /// @notice wormhole bridge adapter proxy
     WormholeBridgeAdapter public wormholeBridge;
 
-    /// @notice event emitted when POKT is bridged to xPOKT
+    /// @notice event emitted when WPOKT is bridged to xPOKT
     event BridgeOutSuccess(uint16 chainId, address indexed to, uint256 amount);
 
     /// @notice initialize the xPOKT router
@@ -79,8 +79,8 @@ contract WPOKTRouter {
         uint256 bridgeCostFee = wormholeBridge.bridgeCost(chainId);
 
         require(
-            bridgeCostFee <= msg.value,
-            "WPOKTRouter: insufficient fee sent"
+            bridgeCostFee == msg.value,
+            "WPOKTRouter: cost not equal to quote"
         );
 
         /// transfer WPOKT to this contract from the sender
@@ -100,14 +100,6 @@ contract WPOKTRouter {
 
         /// bridge the xPOKT to the destination chain
         wormholeBridge.bridge{value: bridgeCostFee}(chainId, xpoktAmount, to);
-
-        /// refund any excess fee sent
-        if (address(this).balance != 0) {
-            (bool success, ) = msg.sender.call{value: address(this).balance}(
-                ""
-            );
-            require(success, "WPOKTRouter: failed to refund excess fee");
-        }
 
         emit BridgeOutSuccess(chainId, to, amount);
     }


### PR DESCRIPTION
**File(s)**: [`WPOKTRouter.sol`](https://github.com/pokt-network/pocket-contracts/blob/932d3f7da9837849bcffba31b95164d8f8f218d5/evm/src/xPOKT/WPOKTRouter.sol#L81)

**Description**: The `_bridgeTo(...)` function facilitates the bridging of `xPOKT` tokens to a target chain. Upon invocation, users are expected to provide a value equal to or greater than the bridging cost (`bridgeCostFee`). However, only the bridging cost is forwarded to the Wormhole bridge, the excess value is always sent back the user. 

```solidity
function _bridgeTo(uint16 chainId, address to, uint256 amount) private {
      uint256 bridgeCostFee = wormholeBridge.bridgeCost(chainId);
      //@audit User can send a value higher than needed (bridgeCostFee) 
      require(
          bridgeCostFee <= msg.value,
          "WPOKTRouter: insufficient fee sent"
      );

      // ...
      // @audit Only `bridgeCostFee` is sent to the wormhole bridge
      wormholeBridge.bridge{value: bridgeCostFee}(chainId, xpoktAmount, to);

      // @audit Excess funds are sent back to the user
      if (address(this).balance != 0) {
          (bool success, ) = msg.sender.call{value: address(this).balance}("");
          require(success, "WPOKTRouter: failed to refund excess fee");
      }
      // ...
 }
```
Allowing a higher `msg.value` than the actual cost is unnecessary and leads to increased gas consumption due to the need for refunding the user.

**Recommendation(s)**: Consider modifying  the condition checking `msg.value` to enforce a strict equality with the bridge cost.
