### PR TITLE
fix(audit): add support for custom gas limit override

### DIFF
--- a/evm/test/unit/WormholeBridgeAdapter.t.sol
+++ b/evm/test/unit/WormholeBridgeAdapter.t.sol
@@ -181,6 +181,11 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         wormholeBridgeAdapterProxy.setGasLimit(1);
     }
 
+    function testSetCustomGasLimitNonOwnerFails() public {
+        vm.expectRevert("Ownable: caller is not the owner");
+        wormholeBridgeAdapterProxy.setCustomGasLimit(1, 1);
+    }
+
     function testRemoveTrustedSendersNonOwnerFails() public {
         vm.expectRevert("Ownable: caller is not the owner");
         wormholeBridgeAdapterProxy.removeTrustedSenders(
@@ -220,6 +225,27 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
 
         assertEq(
             wormholeBridgeAdapterProxy.gasLimit(),
+            newGasLimit,
+            "incorrect new gas limit"
+        );
+    }
+
+    function testSetCustomGasLimitOwnerSucceeds(uint16 chainId, uint96 newGasLimit) public {
+        uint96 defaultGasLimit = wormholeBridgeAdapterProxy.gasLimit();
+        uint96 oldGasLimit = wormholeBridgeAdapterProxy.chainGasLimit(chainId);
+
+        assertEq(
+            defaultGasLimit,
+            oldGasLimit,
+            "gas limits should be equal before custom gas limit set"
+        );
+
+        vm.prank(owner);
+
+        wormholeBridgeAdapterProxy.setCustomGasLimit(chainId, newGasLimit);
+
+        assertEq(
+            wormholeBridgeAdapterProxy.chainGasLimit(chainId),
             newGasLimit,
             "incorrect new gas limit"
         );


### PR DESCRIPTION
**File(s)**: [`WormholeBridgeAdapter`](https://github.com/pokt-network/pocket-contracts/blob/713111a4ed1f278229803ffb14511a583d2e5a90/evm/src/xPOKT/WormholeBridgeAdapter.sol#L107)

**Description**: Before bridging from chain A to chain B through Wormhole protocol, it is necessary to calculate cost through `quoteEVMDeliveryPrice(...)`, which returns an amount of ETH which needs to be paid based on the destination chain and gas limit (estimated amount of gas which will be spent on the execution of `receiveWormholeMessages(...)`)
```solidity
(gasCost, ) = wormholeRelayer.quoteEVMDeliveryPrice(dstChainId, 0, gasLimit);
```
The `gasLimit` is a state variable which can be changed by the owner of the contract to any amount, but by default, it is `300_000`. The problem arises that not every chain calculates gas costs the same as the Ethereum mainnet; therefore, the needed gas could differ on various chains. 

_Note: An example of such a chain is Arbitrum, where the gas amount is calculated by the following equation:_
`Gas Limit (G) = Gas used on L2 (L2G) + Extra Buffer for L1 cost (B)` [Docs](https://docs.arbitrum.io/build-decentralized-apps/how-to-estimate-gas)

If the amount of gas is insufficient for the execution of `receiveWormholeMessages(...).` the wormhole message will need to be resended with a larger gas amount. Furthermore, due to the current usage of `sendPayloadToEvm(...)`, any remaining gas will be sent to the Wormhole delivery contract and not back to the user.


**Recommendation(s)**: Implement a different gas limit for each chain.